### PR TITLE
Update to 0.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.x|5.1.x|5.2.x|5.3.x",
-        "illuminate/console": "5.0.x|5.1.x|5.2.x|5.3.x",
+        "illuminate/support": "5.3.x",
+        "illuminate/console": "5.3.x",
         "symfony/process": "~2.6|~3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.x|5.1.x|5.2.x",
-        "illuminate/console": "5.0.x|5.1.x|5.2.x",
+        "illuminate/support": "5.0.x|5.1.x|5.2.x|5.3.x",
+        "illuminate/console": "5.0.x|5.1.x|5.2.x|5.3.x",
         "symfony/process": "~2.6|~3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.4-dev"
+            "dev-master": "0.5-dev"
         }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Laravel 5 Async Queue Driver
+# Laravel 5.3 Async Queue Driver
 
 ## Push a function/closure to the background.
 

--- a/src/AsyncQueue.php
+++ b/src/AsyncQueue.php
@@ -6,6 +6,7 @@ use DateTime;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\Jobs\DatabaseJob;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Process;
 
 class AsyncQueue extends DatabaseQueue
@@ -154,7 +155,10 @@ class AsyncQueue extends DatabaseQueue
 
         $binary = $this->getPhpBinary();
 
-        return sprintf($cmd, $binary, $id, $connection);
+        $command = sprintf($cmd, $binary, $id, $connection);
+        Log::debug($command);
+
+        return $command;
     }
 
     /**
@@ -179,7 +183,7 @@ class AsyncQueue extends DatabaseQueue
     protected function getBackgroundCommand($cmd)
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            return 'start /B '.$cmd.' > NUL';
+            return 'start "" /B '.$cmd.' > NUL';
         } else {
             return $cmd.' > /dev/null 2>&1 &';
         }

--- a/src/AsyncQueue.php
+++ b/src/AsyncQueue.php
@@ -150,7 +150,7 @@ class AsyncQueue extends DatabaseQueue
     protected function getCommand($id)
     {
         $connection = $this->connectionName;
-        $cmd = '%s artisan queue:async %d %s';
+        $cmd = '"%s" artisan queue:async %d %s';
         $cmd = $this->getBackgroundCommand($cmd);
 
         $binary = $this->getPhpBinary();

--- a/src/Console/AsyncCommand.php
+++ b/src/Console/AsyncCommand.php
@@ -5,6 +5,7 @@ namespace Barryvdh\Queue\Console;
 use Barryvdh\Queue\AsyncQueue;
 use Illuminate\Console\Command;
 use Illuminate\Queue\Worker;
+use Illuminate\Queue\WorkerOptions;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -47,13 +48,13 @@ class AsyncCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function fire(WorkerOptions $options)
     {
         $id = $this->argument('id');
         $connection = $this->argument('connection');
         
         $this->processJob(
-			$connection, $id
+			$connection, $id, $options
 		);
     }
     
@@ -62,7 +63,7 @@ class AsyncCommand extends Command
      *  Process the job
      * 
      */
-    protected function processJob($connectionName, $id)
+    protected function processJob($connectionName, $id, $options)
     {
         $manager = $this->worker->getManager();
         $connection = $manager->connection($connectionName);
@@ -77,7 +78,7 @@ class AsyncCommand extends Command
             $sleep = max($job->getDatabaseJob()->available_at - time(), 0);
             sleep($sleep);
 			return $this->worker->process(
-				$manager->getName($connectionName), $job
+				$manager->getName($connectionName), $job, $options
 			);
 		}
 


### PR DESCRIPTION
This fast forwards our master branch to be equal with the `v0.5.0` tag in the barryvdh version plus the changes that @picklewagon had made in a previous version.

Specifically the changes that he made to wrap the php binary portion of the console command in quotes and to add `""` after `start` in the command.

Then if we switch this line in our composer.json:

`"barryvdh/laravel-async-queue": "0.5.*",`

back to:

`"barryvdh/laravel-async-queue": "dev-master,`

...it should cure what's ailing queues in on-prem currently. That is, they are timing out.